### PR TITLE
Add search and custom tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A comprehensive system for converting Russian audio recipes into structured JSON
 - 🎤 **Audio Transcription**: Convert Russian speech to text using OpenAI Whisper
 - 🤖 **AI-Powered Structuring**: Transform unstructured text into standardized recipe JSON
 - 📁 **Organized Data**: Clean, searchable recipe database
-- 🌐 **React Frontend**: Beautiful recipe book interface (coming soon)
+- 🌐 **React Frontend**: Beautiful recipe book interface
+- 🔍 **Search & Tags**: Filter recipes by title or custom tags in real time
 
 ## Quick Start
 
@@ -114,6 +115,7 @@ python scripts\transcribe\transcribe_audio.py --append
     }
   ],
   "dietary_tags": [],
+  "custom_tags": ["ужин", "быстро"],
   "source": null
 }
 ```
@@ -195,7 +197,7 @@ flake8 scripts/
 - ✅ AI-powered recipe structuring
 - ✅ Comprehensive documentation
 - 🔄 React web application (in progress)
-- 🔮 Recipe search and filtering
+ - ✅ Recipe search and filtering
 - 🔮 Image support
 - 🔮 Export functionality
 

--- a/data/recipes/pasta-with-creamy-cheese-sauce-and-shrimp.json
+++ b/data/recipes/pasta-with-creamy-cheese-sauce-and-shrimp.json
@@ -192,5 +192,6 @@
     }
   ],
   "dietary_tags": [],
+  "custom_tags": ["ужин", "быстро"],
   "source": null
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,6 +54,7 @@ interface Recipe {
   total_time_seconds: number | null; // Total cooking time
   steps: Step[]; // Cooking instructions
   dietary_tags: string[]; // Diet restrictions (if any)
+  custom_tags: string[]; // User-defined tags
   source: string | null; // Original source
 }
 
@@ -223,7 +224,7 @@ python scripts\transcribe\transcribe_audio.py --device cuda
 ## Future Enhancements
 
 - [ ] React web application development
-- [ ] Recipe search and filtering
+ - [x] Recipe search and filtering
 - [ ] Image support for recipes
 - [ ] Export functionality (PDF, etc.)
 - [ ] Multi-language support

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -97,20 +97,21 @@ The Recipe-Book system converts Russian audio recordings into structured recipe 
      ],
      "equipment": ["кастрюля", "сотейник", "сковорода"],
      "total_time_seconds": null,
-     "steps": [
-       {
-         "number": 1,
-         "action": "Разморозьте креветки в холодной воде",
-         "duration_seconds": null,
-         "temperature_celsius": null,
-         "notes": null
-       }
-       // ... more steps
-     ],
-     "dietary_tags": [],
-     "source": null
-   }
-   ```
+    "steps": [
+      {
+        "number": 1,
+        "action": "Разморозьте креветки в холодной воде",
+        "duration_seconds": null,
+        "temperature_celsius": null,
+        "notes": null
+      }
+      // ... more steps
+    ],
+    "dietary_tags": [],
+    "custom_tags": ["ужин", "быстро"],
+    "source": null
+  }
+  ```
 
 5. **Save Recipe File**
    - Create filename using kebab-case: `pasta-with-creamy-cheese-sauce-and-shrimp.json`
@@ -130,6 +131,7 @@ The Recipe-Book system converts Russian audio recordings into structured recipe 
    - Verify ingredient quantities and units
    - Check cooking steps are in logical order
    - Ensure Russian text is preserved correctly
+   - Include relevant custom tags or use an empty array
    - Validate equipment list is complete
 
 3. **Test with Future React App**

--- a/react-app/src/components/RecipeDetailPage.tsx
+++ b/react-app/src/components/RecipeDetailPage.tsx
@@ -37,6 +37,7 @@ const RecipeDetailPage: React.FC = () => {
     prepTime: recipe.total_time_seconds ? `PT${Math.floor(recipe.total_time_seconds / 60)}M` : undefined,
     cookTime: recipe.total_time_seconds ? `PT${Math.floor(recipe.total_time_seconds / 60)}M` : undefined,
     recipeYield: recipe.yield,
+    keywords: recipe.custom_tags.join(', '),
     recipeIngredient: recipe.ingredients.map(ing => {
       const quantity = ing.quantity ? `${ing.quantity} ` : '';
       const unit = ing.unit ? `${ing.unit} ` : '';
@@ -208,6 +209,25 @@ const RecipeDetailPage: React.FC = () => {
                         </li>
                       ))}
                     </ul>
+                  </div>
+                </section>
+              )}
+
+              {recipe.custom_tags.length > 0 && (
+                <section aria-label="Custom tags" className="relative">
+                  <h3 className="text-2xl font-serif text-amber-900 mb-4 text-center border-b border-amber-300 pb-2">
+                    Теги
+                  </h3>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    {recipe.custom_tags.map((tag, index) => (
+                      <Link
+                        key={index}
+                        to={`/?q=${encodeURIComponent(tag)}`}
+                        className="bg-purple-100 text-purple-800 px-3 py-1 rounded-full text-sm font-serif hover:bg-purple-200"
+                      >
+                        {tag}
+                      </Link>
+                    ))}
                   </div>
                 </section>
               )}

--- a/react-app/src/components/RecipeListPage.tsx
+++ b/react-app/src/components/RecipeListPage.tsx
@@ -1,10 +1,30 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState, useMemo, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 import { getAllRecipes } from "../data";
 import { getIngredientCount } from "../utils/getIngredientCount";
 
 const RecipeListPage: React.FC = () => {
   const recipes = getAllRecipes();
+  const location = useLocation();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const q = params.get("q") || "";
+    setSearchQuery(q);
+  }, [location.search]);
+
+  const filteredRecipes = useMemo(() => {
+    const tokens = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return recipes;
+    return recipes.filter((recipe) =>
+      tokens.every(
+        (token) =>
+          recipe.title.toLowerCase().includes(token) ||
+          recipe.custom_tags.some((tag) => tag.toLowerCase().includes(token))
+      )
+    );
+  }, [searchQuery, recipes]);
 
   // Helper function to format time
   const formatTime = (seconds: number | null): string => {
@@ -59,21 +79,39 @@ const RecipeListPage: React.FC = () => {
           </div>
         ) : (
           <>
+            {/* Search Input */}
+            <div className="max-w-md mx-auto mb-8">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Поиск по названию или тегам"
+                className="w-full px-4 py-2 border border-amber-200 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400 font-serif"
+              />
+            </div>
+
             {/* Recipe Count */}
             <div className="text-center mb-8">
               <p className="text-amber-700 font-serif text-lg">
-                Найдено рецептов: <span className="font-bold">{recipes.length}</span>
+                Найдено рецептов: <span className="font-bold">{filteredRecipes.length}</span>
               </p>
             </div>
 
             {/* Recipe Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {recipes.map((recipe) => (
-                <Link
-                  key={recipe.id}
-                  to={`/recipes/${recipe.id}`}
-                  className="group block"
-                >
+            {filteredRecipes.length === 0 ? (
+              <div className="text-center py-16">
+                <div className="text-6xl text-amber-300 mb-4">🍳</div>
+                <h2 className="text-2xl font-serif text-amber-900 mb-2">Рецепты не найдены</h2>
+                <p className="text-amber-700 font-serif">Попробуйте другой запрос или тег</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {filteredRecipes.map((recipe) => (
+                  <Link
+                    key={recipe.id}
+                    to={`/recipes/${recipe.id}`}
+                    className="group block"
+                  >
                   <article className="bg-white/90 backdrop-blur-sm rounded-xl shadow-lg border border-amber-200 overflow-hidden hover:shadow-2xl hover:scale-105 transition-all duration-300 group-hover:border-amber-400">
                     {/* Card Header */}
                     <div className="bg-gradient-to-r from-amber-100 to-orange-100 p-6 border-b border-amber-200">
@@ -188,6 +226,36 @@ const RecipeListPage: React.FC = () => {
                           </div>
                         </div>
                       )}
+
+                      {/* Custom Tags */}
+                      {recipe.custom_tags.length > 0 && (
+                        <div className="mb-4">
+                          <h3 className="text-lg font-serif text-amber-900 mb-3 flex items-center">
+                            <span className="mr-2">🏷️</span>
+                            Теги
+                          </h3>
+                          <div className="flex flex-wrap gap-2">
+                            {recipe.custom_tags.map((tag, index) => (
+                              <span
+                                key={index}
+                                className="text-xs bg-purple-100 text-purple-800 px-2 py-1 rounded-full font-serif cursor-pointer hover:bg-purple-200"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  const lowerTag = tag.toLowerCase();
+                                  setSearchQuery((prev) => {
+                                    const tokens = prev.toLowerCase().split(/\s+/).filter(Boolean);
+                                    if (tokens.includes(lowerTag)) return prev;
+                                    return prev ? `${prev} ${tag}` : tag;
+                                  });
+                                }}
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
 
                     {/* Card Footer */}
@@ -212,7 +280,8 @@ const RecipeListPage: React.FC = () => {
                   </article>
                 </Link>
               ))}
-            </div>
+              </div>
+            )}
           </>
         )}
       </main>

--- a/react-app/src/data/recipes/pasta-with-creamy-cheese-sauce-and-shrimp.json
+++ b/react-app/src/data/recipes/pasta-with-creamy-cheese-sauce-and-shrimp.json
@@ -192,5 +192,6 @@
     }
   ],
   "dietary_tags": [],
+  "custom_tags": ["ужин", "быстро"],
   "source": null
 }

--- a/react-app/src/types/recipe.ts
+++ b/react-app/src/types/recipe.ts
@@ -6,6 +6,7 @@ export interface Recipe {
   total_time_seconds: number | null;
   steps: Step[];
   dietary_tags: string[];
+  custom_tags: string[];
   source: string | null;
 }
 


### PR DESCRIPTION
## Summary
- support searching recipes by title or custom tags and display tags on list and detail views
- extend recipe schema with `custom_tags` and update existing data and docs

## Testing
- `cd react-app && npm test`
- `cd react-app && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6891a081f68c8333895a0476c6739cc8