### PR TITLE
Use import.meta.glob for automatic recipe loading

### DIFF
--- a/react-app/src/data/index.ts
+++ b/react-app/src/data/index.ts
@@ -1,15 +1,17 @@
 import type { Recipe, RecipeWithId } from '../types/recipe';
 
-// Import all recipe JSON files
-import pastaWithCreamyCheeseSauceAndShrimp from './recipes/pasta-with-creamy-cheese-sauce-and-shrimp.json';
+// Import all recipe JSON files dynamically
+const recipeModules = import.meta.glob<Recipe>('./recipes/*.json', {
+  eager: true,
+  import: 'default',
+});
 
-// Create recipes array with IDs
-const recipes: RecipeWithId[] = [
-  {
-    ...pastaWithCreamyCheeseSauceAndShrimp as Recipe,
-    id: 'pasta-with-creamy-cheese-sauce-and-shrimp',
-  },
-];
+// Create recipes array with IDs based on file names
+const recipes: RecipeWithId[] = Object.entries(recipeModules).map(([path, recipe]) => {
+  const fileName = path.split('/').at(-1) ?? '';
+  const id = fileName.replace(/\.json$/, '');
+  return { ...recipe, id };
+});
 
 export default recipes;
 

--- a/react-app/src/data/recipes/simple-omelette.json
+++ b/react-app/src/data/recipes/simple-omelette.json
@@ -1,0 +1,20 @@
+{
+  "title": "Simple Omelette",
+  "yield": "1 serving",
+  "ingredients": [
+    { "quantity": 2, "unit": "pcs", "item": "eggs", "descriptor": null, "optional": false },
+    { "quantity": 1, "unit": "tbsp", "item": "butter", "descriptor": null, "optional": false },
+    { "quantity": null, "unit": null, "item": "salt", "descriptor": null, "optional": false },
+    { "quantity": null, "unit": null, "item": "pepper", "descriptor": "ground", "optional": false }
+  ],
+  "equipment": ["pan", "spatula", "bowl", "fork"],
+  "total_time_seconds": null,
+  "steps": [
+    { "number": 1, "action": "Beat eggs with salt and pepper", "duration_seconds": null, "temperature_celsius": null, "notes": null },
+    { "number": 2, "action": "Melt butter in pan", "duration_seconds": null, "temperature_celsius": null, "notes": null },
+    { "number": 3, "action": "Cook egg mixture until set", "duration_seconds": null, "temperature_celsius": null, "notes": null }
+  ],
+  "dietary_tags": [],
+  "custom_tags": ["breakfast"],
+  "source": null
+}


### PR DESCRIPTION
## Summary
- replace manual recipe imports with `import.meta.glob` to gather all JSON recipes and derive IDs
- add sample omelette recipe demonstrating automatic list updates

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6891a506b6b483338acc0ee463aa5d8e